### PR TITLE
Patch: Add approval modal

### DIFF
--- a/src/components/Modals/TransactionStatus/index.tsx
+++ b/src/components/Modals/TransactionStatus/index.tsx
@@ -65,9 +65,11 @@ const TransactionStatus: React.FC<ITransactionStatus> = ({ type }) => {
           </StyledTractorContainer>
         </StyledIconsContainer>
         <Spacer size={'md'} />
-        <P1 center={true} color={colors.white}>
-          {actionType === 'deposit' ? 'Deposit' : 'Withdraw'} {displayValue} wPOKT
-        </P1>
+        {displayValue !== '' && (
+          <P1 center={true} color={colors.white}>
+            {actionType === 'deposit' ? 'Deposit' : 'Withdraw'} {displayValue} wPOKT
+          </P1>
+        )}
       </StyledInnerContainer>
     </StyledModalContainer>
   );

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -15,7 +15,7 @@ const Modals: React.FC = () => {
       {modalOpen && (
         <>
           <StyledBackground onClick={onCloseModal} />
-          {selectedModal === 'CONFIRM_DEPOSIT' && <ConfirmTransaction />}
+          {selectedModal === 'CONFIRM_TRANSACTION' && <ConfirmTransaction />}
           {(selectedModal === 'TRANSACTION_WAITING' ||
             selectedModal === 'TRANSACTION_APPROVED' ||
             selectedModal === 'TRANSACTION_REJECTED') && <TransactionStatus type={selectedModal} />}

--- a/src/contexts/DepositWithdrawal/index.tsx
+++ b/src/contexts/DepositWithdrawal/index.tsx
@@ -7,7 +7,7 @@ import { parseInputValue, stake, unstake } from 'utils';
 
 type IModalType =
   | ''
-  | 'CONFIRM_DEPOSIT'
+  | 'CONFIRM_TRANSACTION'
   | 'TRANSACTION_WAITING'
   | 'TRANSACTION_APPROVED'
   | 'TRANSACTION_REJECTED'
@@ -83,7 +83,7 @@ export const DepositWithdrawalProvider: React.FC = ({ children }) => {
 
   const onSelectModal = (modalType: IModalType): void => {
     switch (modalType) {
-      case 'CONFIRM_DEPOSIT':
+      case 'CONFIRM_TRANSACTION':
         setModalOpen(true);
         setSelectedModal(modalType);
         break;

--- a/src/views/DepositWithdraw/components/EnterAmount/index.tsx
+++ b/src/views/DepositWithdraw/components/EnterAmount/index.tsx
@@ -51,6 +51,7 @@ export const EnterAmount: React.FC<IEnterAmount> = ({ actionType, farmSelected, 
   const { isApproved, isApproving, onApprove } = useApproval();
   const { totalStaked } = useUserStats(address ? address : '', TOKEN_GEYSER_ADDRESS);
 
+  const [didApprove, setDidApprove] = React.useState<boolean>(false);
   const [isDisabled, setIsDisabled] = React.useState<boolean>(true);
 
   React.useEffect(() => {
@@ -81,17 +82,24 @@ export const EnterAmount: React.FC<IEnterAmount> = ({ actionType, farmSelected, 
 
   React.useEffect(() => {
     if (isApproving) {
-      console.log('Approving...');
-    } else if (isApproved) {
-      console.log('Approved');
+      setDidApprove(true);
+      onSelectModal('TRANSACTION_WAITING');
     }
-  }, [isApproving, isApproved]);
+
+    if (didApprove && isApproved) {
+      onSelectModal('TRANSACTION_APPROVED');
+      setDidApprove(false);
+    } else if (didApprove && !isApproving) {
+      onSelectModal('TRANSACTION_REJECTED');
+      setDidApprove(false);
+    }
+  }, [didApprove, isApproved, isApproving, onSelectModal]);
 
   const onConfirmDeposit = async () => {
     readyToTransact(onboard, provider);
     if (address && signer && !isDisabled && farmSelected) {
       if (isApproved) {
-        onSelectModal('CONFIRM_DEPOSIT');
+        onSelectModal('CONFIRM_TRANSACTION');
       } else {
         onApprove();
       }


### PR DESCRIPTION
Current app logs approval status, but doesn't launch modal. This patch now calls the transaction status modal when app is being approved.