### PR TITLE
Fix ownership share percentage on views

### DIFF
--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+              statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+              statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare.toFixed(2)}%`}
+              statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+            statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare.toFixed(2)}%`}
+            statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+            statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -121,7 +121,9 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'question'}
                   statTitle={'Farm ownership'}
-                  statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+                  statContent={`${
+                    ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
+                  }%`}
                 />
                 <SmallInfoCard
                   iconType={'question'}

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -122,7 +122,7 @@ const MyFarms: React.FC = () => {
                   iconType={'question'}
                   statTitle={'Farm ownership'}
                   statContent={`${
-                    ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
+                    ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
                   }%`}
                 />
                 <SmallInfoCard

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -121,7 +121,7 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'question'}
                   statTitle={'Farm ownership'}
-                  statContent={`${ownershipShare.toFixed(2)}%`}
+                  statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
                 />
                 <SmallInfoCard
                   iconType={'question'}


### PR DESCRIPTION
As soon as you stake, your ownership share is too small to be seen if we use `.toFixed(2)`. What we are trying to do here, is show `< 0.01%` if your ownership share is below 0.01 and different than 0. That way the user is not confused about his share not going up immediately after staking.

Case 1: User has 0 ownership, it shows as `0.00%`
Case 2: User has 0.0001% ownership, it shows as `< 0.01%`
Case 3: User has 0.1 ownership, it shows as `0.10%` 

