### PR TITLE
Fix max relays in various views

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,8 +12,6 @@ export function commifyString(number: string): string {
 
 export function formatRelays(relays: string | BNJS): string {
   const relaysByMillion = new BNJS(relays).div(new BNJS(1000000));
-  // eslint-disable-next-line prettier/prettier
-  
   return relaysByMillion.toFixed(2);
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ import { BigNumber, ContractInterface, ContractTransaction, ethers, Signer, util
 import { Provider } from '@ethersproject/abstract-provider';
 import ERC20ABI from 'abis/ERC20.json';
 import TokenGeyserABI from 'abis/TokenGeyser.json';
+import { BigNumber as BNJS } from 'bignumber.js';
 
 export function commifyString(number: string): string {
   const parts = number.split('.');
@@ -9,9 +10,11 @@ export function commifyString(number: string): string {
   return parts.join('.');
 }
 
-export function formatRelays(relays: string | BigInt): string {
-  const relaysByMillion = BigInt(relays) / 1000000n;
-  return relaysByMillion.toString();
+export function formatRelays(relays: string | BNJS): string {
+  const relaysByMillion = new BNJS(relays).div(new BNJS(1000000));
+  // eslint-disable-next-line prettier/prettier
+  
+  return relaysByMillion.toFixed(2);
 }
 
 export function formatFillPercentage(timeLeft?: number, totalTime?: number): number {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -37,6 +37,10 @@ function bigNum(value: string | number): BigNumber {
   return BigNumber.from(value);
 }
 
+export function formatOwnershipShare(share: number): string {
+  return share >= 0.01 || share === 0 ? share.toFixed(2) : '< 0.01';
+}
+
 /**
  * Format a decimal-based number back to a big number
  *

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+              statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -70,7 +70,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
         <SmallInfoCard
           iconType={'question'}
           statTitle={'MAX RELAYS/DAY'}
-          statContent={`${formatRelays(maxRelays.toFixed(0))} M`}
+          statContent={`${formatRelays(maxRelays)} M`}
         />
         <SmallInfoCard
           iconType={'question'}

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+              statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -106,7 +106,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare.toFixed(2)}%`}
+              statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/DepositInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/DepositInfo/index.tsx
@@ -26,7 +26,13 @@ import { TOKEN_GEYSER_ADDRESS } from 'constants/index';
 import { useFarmStats } from 'hooks/useFarmStats';
 import { useUserStats } from 'hooks/useUserStats';
 
-import { commifyString, formatDaysFromTimestamp, formatFillPercentage, formatRelays } from 'utils';
+import {
+  commifyString,
+  formatDaysFromTimestamp,
+  formatFillPercentage,
+  formatRelays,
+  formatOwnershipShare,
+} from 'utils';
 
 interface IDepositInfo {
   farmSelected: boolean;
@@ -106,7 +112,7 @@ export const DepositInfo: React.FC<IDepositInfo> = ({ farmSelected }) => {
             <SmallInfoCard
               iconType={'question'}
               statTitle={'Farm Ownership'}
-              statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+              statContent={`${formatOwnershipShare(ownershipShare)}%`}
             />
             <SmallInfoCard iconType={'caret'} statTitle={'Apps'} statContent={'0'} />
             <SmallInfoCard iconType={'question'} statTitle={'Usage'} statContent={`${farmUsage.toFixed(2)}%`} />

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -25,7 +25,13 @@ import { Web3Context } from 'contexts/Web3';
 import { useFarmStats } from 'hooks/useFarmStats';
 import { useUserStats } from 'hooks/useUserStats';
 
-import { commifyString, formatDaysFromTimestamp, formatFillPercentage, formatRelays } from 'utils';
+import {
+  commifyString,
+  formatDaysFromTimestamp,
+  formatFillPercentage,
+  formatOwnershipShare,
+  formatRelays,
+} from 'utils';
 
 interface IWithdraw {
   farmSelected: boolean;
@@ -106,7 +112,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+            statContent={`${formatOwnershipShare(ownershipShare)}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+            statContent={`${ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare.toFixed(2)}%`}
+            statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -106,7 +106,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'Farm Ownership'}
-            statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+            statContent={`${ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
           />
           <SmallInfoCard
             iconType={'caret'}

--- a/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
+++ b/src/views/DepositWithdraw/components/WithdrawInfo/index.tsx
@@ -117,7 +117,7 @@ const WithdrawFarm: React.FC<IWithdrawFarm> = ({ address, farmSelected }) => {
           <SmallInfoCard
             iconType={'question'}
             statTitle={'MAX RELAYS/DAY'}
-            statContent={`${formatRelays(maxRelays.toFixed(0))} M`}
+            statContent={`${formatRelays(maxRelays)} M`}
           />
           <SmallInfoCardExtraLinks showOnDesktop={true} showOnMobile={true} />
         </StyledContentContainer>

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -121,7 +121,9 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'question'}
                   statTitle={'Farm ownership'}
-                  statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
+                  statContent={`${
+                    ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
+                  }%`}
                 />
                 <SmallInfoCard
                   iconType={'question'}

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -37,7 +37,13 @@ import { Web3Context } from 'contexts/Web3';
 import { useFarmStats } from 'hooks/useFarmStats';
 import { useUserStats } from 'hooks/useUserStats';
 
-import { commifyString, formatDaysFromTimestamp, formatFillPercentage, formatRelays } from 'utils';
+import {
+  commifyString,
+  formatDaysFromTimestamp,
+  formatFillPercentage,
+  formatOwnershipShare,
+  formatRelays,
+} from 'utils';
 
 const MyFarms: React.FC = () => {
   const history = useHistory();
@@ -121,9 +127,7 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'question'}
                   statTitle={'Farm ownership'}
-                  statContent={`${
-                    ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
-                  }%`}
+                  statContent={`${formatOwnershipShare(ownershipShare)}%`}
                 />
                 <SmallInfoCard
                   iconType={'question'}

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -122,7 +122,7 @@ const MyFarms: React.FC = () => {
                   iconType={'question'}
                   statTitle={'Farm ownership'}
                   statContent={`${
-                    ownershipShare > 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
+                    ownershipShare >= 0.01 || ownershipShare === 0 ? ownershipShare.toFixed(2) : '< 0.01'
                   }%`}
                 />
                 <SmallInfoCard

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -121,7 +121,7 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'question'}
                   statTitle={'Farm ownership'}
-                  statContent={`${ownershipShare.toFixed(2)}%`}
+                  statContent={`${ownershipShare > 0.01 ? ownershipShare.toFixed(2) : '< 0.01'}%`}
                 />
                 <SmallInfoCard
                   iconType={'question'}

--- a/src/views/MyFarms/index.tsx
+++ b/src/views/MyFarms/index.tsx
@@ -105,7 +105,7 @@ const MyFarms: React.FC = () => {
                 <SmallInfoCard
                   iconType={'caret'}
                   statTitle={'Max Relays/Day'}
-                  statContent={`${formatRelays(maxRelays.toFixed(0))} M`}
+                  statContent={`${formatRelays(maxRelays)} M`}
                 />
                 <SmallInfoCard
                   iconType={'question'}


### PR DESCRIPTION
Basically everywhere 'Max Relays' was being displayed, if the amount was below 1 million, it would show `0 M`. This fixes that behavior, and it now shows `X.XX M`


Builds on #30. 